### PR TITLE
Add CircleCI config, using a custom jdk-12 docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,29 @@
+version: 2
+jobs:
+  build:
+    docker:
+      # see https://hub.docker.com/r/codeaches/openjdk
+      - image: codeaches/openjdk:12-jdk
+
+    working_directory: ~/repo
+
+    environment:
+      JVM_OPTS: -Xmx3200m
+      TERM: dumb
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "build.gradle" }}
+            - v1-dependencies-
+
+      - run: gradle dependencies
+
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: v1-dependencies-{{ checksum "build.gradle" }}
+
+      - run: gradle test


### PR DESCRIPTION
I'm using JDK 12 in my project, but [CircleCI does not yet have a Docker image for it](https://github.com/circleci/circleci-images/issues/389).

I began by following [this advice](https://discuss.circleci.com/t/upgrade-to-jdk12/29566/7): using one of the [OpenJDK images](https://hub.docker.com/_/openjdk) and installing git and gradle myself from within the CircleCI config.

But then I found [this custom image someone had built](https://discuss.circleci.com/t/upgrade-to-jdk12/29566/8) and went with that. Is this an ok option? Out of curiosity, could there be security implications if I cared about the privacy of this repo?