### PR TITLE
Auto deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,29 @@
+version: 2
+jobs:
+  build:
+    docker:
+      # see https://hub.docker.com/r/codeaches/openjdk
+      - image: codeaches/openjdk:12-jdk
+
+    working_directory: ~/repo
+
+    environment:
+      JVM_OPTS: -Xmx3200m
+      TERM: dumb
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "build.gradle" }}
+            - v1-dependencies-
+
+      - run: gradle dependencies
+
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: v1-dependencies-{{ checksum "build.gradle" }}
+
+      - run: gradle test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,5 @@
-version: 2
+version: 2.1
+
 jobs:
   build:
     docker:
@@ -26,4 +27,38 @@ jobs:
             - ~/.gradle
           key: v1-dependencies-{{ checksum "build.gradle" }}
 
-      - run: gradle test
+      - run: gradle build
+
+      - persist_to_workspace:
+          root: ~/repo/jar
+          paths:
+            - httpserver-1.0-SNAPSHOT.jar
+
+
+  deploy:
+    machine: true
+    steps:
+
+      - attach_workspace:
+          at: /tmp/workspace
+
+      - add_ssh_keys:
+          fingerprints:
+            - "78:11:cd:e5:32:0f:71:41:27:c9:a9:2a:5e:3c:d9:91"
+
+      - run:
+          name: Send JAR to Server
+          command: |
+            scp /tmp/workspace/httpserver-1.0-SNAPSHOT.jar $SSH_USER@$SSH_HOST:$SSH_DEPLOY_PATH
+
+workflows:
+  version: 2
+  build-and-deploy:
+    jobs:
+      - build
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master


### PR DESCRIPTION
Send JAR file to Digital Ocean over SSH if the build passes on the `master` branch

- After building, store the JAR file in a CircleCI workspace and access it again in the `deploy` job.